### PR TITLE
Added a 'no trailer' option

### DIFF
--- a/csvdiff.go
+++ b/csvdiff.go
@@ -61,7 +61,7 @@ func atouis(s string) (values []int) {
 // TODO Add an option to ignore appended/new field(s).
 func parseArgs() *config {
 	var n = flag.Bool("n", false, "No header")
-	var f = flag.Int("f", 0, "Format used to display delta (0: ansi bold, 1: piped, 2: newline, 3: none)")
+	var f = flag.Int("f", 0, "Format used to display delta (0: ansi bold, 1: piped, 2: newline)")
 	var q = flag.Bool("q", true, "Quoted field mode")
 	var sep = flag.String("s", ",", "Set the field separator")
 	var k = flag.String("k", "", "Set the key indexes (starts at 1). '*' means all columns are part of the key")

--- a/csvdiff.go
+++ b/csvdiff.go
@@ -224,9 +224,6 @@ func concat(valueA, valueB []byte, format int, symbol byte) []byte {
 		return bytes.Join([][]byte{valueA, valueB}, []byte{symbol, '-', symbol})
 	case 2:
 		return bytes.Join([][]byte{valueA, valueB}, []byte{'\n'})
-	case 3:
-		return bytes.Join([][]byte{valueA, valueB}, []byte{symbol})
-
 	}
 
 	buf := []byte{}


### PR DESCRIPTION
What Was The Problem:
-----------------------------------

When csvdiff is used as part of a pipeline of applications the trailer (Totals etc) can cause issues when a subsequent  application uses go-langs own CSV parser. The reason for this is the go-lang parser assumes the number of columns is always the same.

What Did I Do To Solve This:
-----------------------------------
I Added a 't' option to the configuration parameters and when added to an executing command the trailer is not  displayed.

What Do I Verify This:
-----------------------------------
After building the application type:

    csvdiff --help

And you should see:

    -t   No trailer

When you do a diff with the -t option then no trailer should be seen.
